### PR TITLE
Add api-version to plugin.yml

### DIFF
--- a/Plugin/src/main/resources/plugin.yml
+++ b/Plugin/src/main/resources/plugin.yml
@@ -2,6 +2,7 @@ name: "LibreLogin"
 author: "kyngs"
 version: 0.13.5
 main: "xyz.kyngs.librelogin.paper.PaperBootstrap"
+api-version: 1.13
 
 depend:
   - ProtocolLib


### PR DESCRIPTION
This will remove the error about LibreLogin being a 'legacy plugin' for not having an api-version.