### PR TITLE
Add regex validation option

### DIFF
--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/AuthenticLibreLogin.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/AuthenticLibreLogin.java
@@ -155,15 +155,14 @@ public abstract class AuthenticLibreLogin<P, S> implements LibreLoginPlugin<P, S
 
     @Override
     public boolean validPassword(String password) {
-        var length = password.length() >= configuration.get(MINIMUM_PASSWORD_LENGTH);
+        String regex = configuration.get(REGEX_PATTERN);
+        String upper = password.toUpperCase();
 
-        if (!length) {
-            return false;
-        }
+        boolean isRegexValida = regex.equals("") || password.matches(regex);
+        boolean isValidLength = password.length() >= configuration.get(MINIMUM_PASSWORD_LENGTH);
+        boolean isForbidden = forbiddenPasswords.contains(upper);
 
-        var upper = password.toUpperCase();
-
-        return !forbiddenPasswords.contains(upper);
+        return isValidLength && isRegexValida && !isForbidden;
     }
 
     @Override

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/command/Command.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/command/Command.java
@@ -77,7 +77,14 @@ public class Command<P> extends BaseCommand {
 
     protected void setPassword(Audience sender, User user, String password, String messageKey) {
         if (!plugin.validPassword(password))
-            throw new InvalidCommandArgument(getMessage("error-forbidden-password"));
+        {
+            if(!getMessage("custom-validation-message").content().equals("")) {
+                throw new InvalidCommandArgument(getMessage("custom-validation-message"));
+            }
+            else {
+                throw new InvalidCommandArgument(getMessage("error-forbidden-password"));
+            }
+        }
 
         sender.sendMessage(getMessage(messageKey));
 

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/config/ConfigurationKeys.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/config/ConfigurationKeys.java
@@ -345,4 +345,11 @@ public class ConfigurationKeys {
                     This section is used for configuring the email password recovery feature.
                     """
     );
+
+    public static final ConfigurationKey<String> REGEX_PATTERN = new ConfigurationKey<>(
+            "regex-pattern",
+            "",
+            "Regex pattern for password validation. Set empty to disable",
+            ConfigurateHelper::getString
+    );
 }

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/config/MessageKeys.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/config/MessageKeys.java
@@ -1171,4 +1171,11 @@ public class MessageKeys {
             "This hint is displayed when the player starts typing the /confirmpasswordreset command.",
             ConfigurateHelper::getString
     );
+
+    public static final ConfigurationKey<String> CUSTOM_VALIDATION_MESSAGE = new ConfigurationKey<>(
+            "custom-validation-message",
+            "",
+            "This message is displayed when the player tries to register with a password that is not valid for your regex validation. You need to set if you have one!",
+            ConfigurateHelper::getString
+    );
 }


### PR DESCRIPTION
Is it now possible for the operator of the serever to perform a RegeEx authentication during the registration process, which can be entered in the regex-pattern configuration field. It is also possible to return a custom error message in case of an incorrect password during registration with the custom-validation-message message key.