### PR TITLE
Revert "Bump org.xerial:sqlite-jdbc from 3.43.0.0 to 3.43.2.0"

### DIFF
--- a/Plugin/build.gradle
+++ b/Plugin/build.gradle
@@ -82,7 +82,7 @@ dependencies {
     libby 'com.zaxxer:HikariCP:5.0.1'
 
     //SQLite
-    libby 'org.xerial:sqlite-jdbc:3.43.2.0'
+    libby 'org.xerial:sqlite-jdbc:3.43.0.0'
 
     //PostgreSQL
     libby 'org.postgresql:postgresql:42.6.0'


### PR DESCRIPTION
Reverts kyngs/LibreLogin#150
It seems to cause some weird slf4j issues.