### PR TITLE
Add option to allow revert the /back exploit fix

### DIFF
--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/config/ConfigurationKeys.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/config/ConfigurationKeys.java
@@ -46,7 +46,7 @@ public class ConfigurationKeys {
     public static final ConfigurationKey<Boolean> LIMBO_ALLOW_TP = new ConfigurationKey<>(
             "limbo-allow-tp",
             false,
-            "Reverts the /back exploit fix to allow players to teleport to the limbo dimension manually.",
+            "Reverts the /back exploit fix to allow players to teleport to the limbo world.",
             ConfigurateHelper::getBoolean
     );
 

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/config/ConfigurationKeys.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/config/ConfigurationKeys.java
@@ -43,6 +43,13 @@ public class ConfigurationKeys {
             ConfigurateHelper::getStringList
     );
 
+    public static final ConfigurationKey<Boolean> LIMBO_ALLOW_TP = new ConfigurationKey<>(
+            "limbo-allow-tp",
+            false,
+            "Reverts the /back exploit fix to allow players to teleport to the limbo dimension manually.",
+            ConfigurateHelper::getBoolean
+    );
+
     public static final Multimap<String, String> LOBBY_DEFAULT = HashMultimap.create();
     public static final ConfigurationKey<Multimap<String, String>> LOBBY = new ConfigurationKey<>(
             "lobby",

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/paper/Blockers.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/paper/Blockers.java
@@ -23,9 +23,10 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.*;
 import xyz.kyngs.librelogin.api.authorization.AuthorizationProvider;
 import xyz.kyngs.librelogin.api.server.ServerHandler;
+import xyz.kyngs.librelogin.common.config.ConfigurationKeys;
 import xyz.kyngs.librelogin.common.config.HoconPluginConfiguration;
 
-import static xyz.kyngs.librelogin.common.config.ConfigurationKeys.ALLOWED_COMMANDS_WHILE_UNAUTHORIZED;
+import static xyz.kyngs.librelogin.common.config.ConfigurationKeys.*;
 
 public class Blockers implements Listener {
 
@@ -55,12 +56,16 @@ public class Blockers implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onTeleport(PlayerTeleportEvent event) {
-        if (inLimbo(event.getPlayer())) {
-            event.setCancelled(true);
-        } else {
-            if (serverHandler.getLimboServers().contains(event.getTo().getWorld())) {
+        if (!configuration.get(LIMBO_ALLOW_TP)) {
+            if (inLimbo(event.getPlayer())) {
                 event.setCancelled(true);
+            } else {
+                if (serverHandler.getLimboServers().contains(event.getTo().getWorld())) {
+                    event.setCancelled(true);
+                }
             }
+       } else {
+            cancelIfNeeded(event);
         }
     }
 


### PR DESCRIPTION
Helpful for servers that use the lobby world as more than just a lobby world. Allows for players to be sent to the world when using commands.