### PR TITLE
Log stack trace as a warning if update check fails.

### DIFF
--- a/Plugin/build.gradle.kts
+++ b/Plugin/build.gradle.kts
@@ -21,7 +21,7 @@ mcupload {
             loaders = listOf("paper", "purpur", "bungeecord", "waterfall", "velocity")
             projectId = "tL0SCXYq"
             gameVersions = listOf(
-                "1.21.0",
+                "1.21",
                 "1.20.6", "1.20.5", "1.20.4", "1.20.3", "1.20.2", "1.20.1", "1.20",
                 "1.19.4", "1.19.3", "1.19.2", "1.19.1", "1.19",
                 "1.18.2", "1.18.1", "1.18",

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/AuthenticLibreLogin.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/AuthenticLibreLogin.java
@@ -670,8 +670,7 @@ public abstract class AuthenticLibreLogin<P, S> implements LibreLoginPlugin<P, S
                 logger.warn("!! PLEASE UPDATE TO THE LATEST VERSION !!");
             }
         } catch (Exception e) {
-            e.printStackTrace();
-            logger.warn("Failed to check for updates");
+            logger.warn("Failed to check for updates", e);
         }
     }
 


### PR DESCRIPTION
## Motivation

Right now, the code prints a full stack trace with `e.printStackTrace()`, which shows up in red and can make people think something is broken, when in fact it's just a failed update check.

### Examples

https://github.com/kyngs/LibreLogin/issues/248

https://github.com/kyngs/LibreLogin/issues/75#issuecomment-1596171467

![](https://github.com/user-attachments/assets/de933e9c-abb5-4e11-b596-a518342066c6)

