### PR TITLE
Remove PremiumException.Issue.UNDEFINED issue to not fallback

### DIFF
--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/premium/AuthenticPremiumProvider.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/premium/AuthenticPremiumProvider.java
@@ -63,7 +63,11 @@ public class AuthenticPremiumProvider implements PremiumProvider {
                     if (i == fetchers.size() - 1) {
                         exceptionToThrow[0] = e;
                     } else if (e.getIssue() == PremiumException.Issue.SERVER_EXCEPTION) {
-                        plugin.getLogger().warn("Got server exception while fetching premium user, falling back to an another API", e);
+                        plugin.getLogger().warn("Got a server exception while fetching premium user. Falling back to an alternative API. Player's information's might not be up-to-date.", e);
+                    } else if (e.getIssue() == PremiumException.Issue.THROTTLED) {
+                        plugin.getLogger().warn("Your IP has been rate limited while fetching premium user. Falling back to an alternative API. Player's information's might not be up-to-date.", e);
+                    } else {
+                        plugin.getLogger().warn("Got unexpected exception while fetching premium user. Falling back to an alternative API. Player's information's might not be up-to-date.", e);
                     }
                 } catch (RuntimeException e) {
                     plugin.getLogger().debug("Unexpected exception while fetching premium user " + finalName, e);

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/premium/AuthenticPremiumProvider.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/premium/AuthenticPremiumProvider.java
@@ -60,11 +60,6 @@ public class AuthenticPremiumProvider implements PremiumProvider {
                 try {
                     return fetcher.apply(x);
                 } catch (PremiumException e) {
-                    if (i == 0 && e.getIssue() == PremiumException.Issue.UNDEFINED) {
-                        exceptionToThrow[0] = e;
-                        break;
-                    }
-
                     if (i == fetchers.size() - 1) {
                         exceptionToThrow[0] = e;
                     } else if (e.getIssue() == PremiumException.Issue.SERVER_EXCEPTION) {


### PR DESCRIPTION
I don't see the reason why we should not fallback if a server gives back an unexpected "undefined" response. Because is an api issue we can't predict what the issue will be.