### PR TITLE
fix: Bad LogFilter

### DIFF
--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/log/Log4JFilter.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/log/Log4JFilter.java
@@ -14,6 +14,15 @@ import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.message.Message;
 
+/**
+ * A Log4J implementation of the LogFilter that filters out sensitive authentication commands.
+ * <p>
+ * This class extends {@link LogFilter} and implements Log4J's {@link Filter} interface to provide filtering capabilities for Log4J logging system.
+ * <p>
+ * The filter is designed to prevent logging of sensitive information such as passwords and authentication tokens that might appear in certain commands. It integrates with Log4J's filtering chain and can be easily added to the root logger.
+ * <p>
+ * This implementation handles various Log4J filter method overloads to ensure comprehensive coverage of all possible logging scenarios, including parameterized messages and raw objects.
+ */
 public class Log4JFilter extends LogFilter implements Filter {
 
     @Override
@@ -21,8 +30,16 @@ public class Log4JFilter extends LogFilter implements Filter {
         ((Logger) LogManager.getRootLogger()).addFilter(new Log4JFilter());
     }
 
-    private Result checkMessageResult(String message) {
-        return checkMessage(message) ? Result.NEUTRAL : Result.DENY;
+    /**
+     * Converts the result of message checking into a Log4J {@link Filter#Result}.
+     *
+     * @param message The message pattern to be checked
+     * @param parameters The parameters associated with the message. Must not be null
+     * @return {@link Result#NEUTRAL} if the message should be logged, {@link Result#DENY} if it should be filtered out
+     * @see LogFilter#checkMessage
+     */
+    private Result checkMessageResult(String message, Object[] parameters) {
+        return checkMessage(message, parameters) ? Result.NEUTRAL : Result.DENY;
     }
 
     @Override
@@ -37,72 +54,73 @@ public class Log4JFilter extends LogFilter implements Filter {
 
     @Override
     public Result filter(Logger logger, Level level, Marker marker, String message, Object... params) {
-        return checkMessageResult(message);
+        return checkMessageResult(message, params);
     }
 
     @Override
     public Result filter(Logger logger, Level level, Marker marker, String message, Object p0) {
-        return checkMessageResult(message);
+        return checkMessageResult(message, new Object[]{p0});
     }
 
     @Override
     public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1) {
-        return checkMessageResult(message);
+        return checkMessageResult(message, new Object[]{p0, p1});
     }
 
     @Override
     public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1, Object p2) {
-        return checkMessageResult(message);
+        return checkMessageResult(message, new Object[]{p0, p1, p2});
     }
 
     @Override
     public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3) {
-        return checkMessageResult(message);
+        return checkMessageResult(message, new Object[]{p0, p1, p2, p3});
     }
 
     @Override
     public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
-        return checkMessageResult(message);
+        return checkMessageResult(message, new Object[]{p0, p1, p2, p3, p4});
     }
 
     @Override
     public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
-        return checkMessageResult(message);
+        return checkMessageResult(message, new Object[]{p0, p1, p2, p3, p4, p5});
     }
 
     @Override
     public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
-        return checkMessageResult(message);
+        return checkMessageResult(message, new Object[]{p0, p1, p2, p3, p4, p5, p6});
     }
 
     @Override
     public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7) {
-        return checkMessageResult(message);
+        return checkMessageResult(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7});
     }
 
     @Override
     public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7, Object p8) {
-        return checkMessageResult(message);
+        return checkMessageResult(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8});
     }
 
     @Override
     public Result filter(Logger logger, Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7, Object p8, Object p9) {
-        return checkMessageResult(message);
+        return checkMessageResult(message, new Object[]{p0, p1, p2, p3, p4, p5, p6, p7, p8, p9});
     }
 
     @Override
     public Result filter(Logger logger, Level level, Marker marker, Object msg, Throwable t) {
-        return checkMessageResult(msg.toString());
+        return checkMessageResult(msg.toString(), new Object[0]);
     }
 
     @Override
     public Result filter(Logger logger, Level level, Marker marker, Message msg, Throwable t) {
-        return checkMessageResult(msg.getFormattedMessage());
+        return checkMessageResult(msg.getFormat(), msg.getParameters());
     }
 
     @Override
     public Result filter(LogEvent event) {
-        return checkMessageResult(event.getMessage().getFormattedMessage());
+        var message = event.getMessage();
+        return checkMessageResult(message.getFormat(), message.getParameters());
     }
 
     @Override

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/log/Log4JFilter.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/log/Log4JFilter.java
@@ -15,7 +15,7 @@ import org.apache.logging.log4j.core.Logger;
 import org.apache.logging.log4j.message.Message;
 
 /**
- * A Log4J implementation of the LogFilter that filters out sensitive authentication commands.
+ * A Log4J implementation of the {@link LogFilter} that filters out sensitive authentication commands.
  * <p>
  * This class extends {@link LogFilter} and implements Log4J's {@link Filter} interface to provide filtering capabilities for Log4J logging system.
  * <p>
@@ -31,7 +31,7 @@ public class Log4JFilter extends LogFilter implements Filter {
     }
 
     /**
-     * Converts the result of message checking into a Log4J {@link Filter#Result}.
+     * Converts the result of message checking into a Log4J {@link Result}.
      *
      * @param message The message pattern to be checked
      * @param parameters The parameters associated with the message. Must not be null

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/log/Log4JFilter.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/log/Log4JFilter.java
@@ -34,7 +34,7 @@ public class Log4JFilter extends LogFilter implements Filter {
      * Converts the result of message checking into a Log4J {@link Result}.
      *
      * @param message The message pattern to be checked
-     * @param parameters The parameters associated with the message. Must not be null
+     * @param parameters The parameters associated with the message.
      * @return {@link Result#NEUTRAL} if the message should be logged, {@link Result#DENY} if it should be filtered out
      * @see LogFilter#checkMessage
      */
@@ -109,7 +109,7 @@ public class Log4JFilter extends LogFilter implements Filter {
 
     @Override
     public Result filter(Logger logger, Level level, Marker marker, Object msg, Throwable t) {
-        return checkMessageResult(msg.toString(), new Object[0]);
+        return checkMessageResult(msg.toString(), null);
     }
 
     @Override

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/log/LogFilter.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/log/LogFilter.java
@@ -43,11 +43,11 @@ public abstract class LogFilter {
      * Checks if a log message containing a command should be filtered out.
      *
      * @param message The message pattern being logged
-     * @param parameters The parameters being used in the message. Must not be null
+     * @param parameters The parameters being used in the message.
      * @return {@code true} if the message should be logged, {@code false} if it should be filtered out
      */
     protected boolean checkMessage(String message, Object[] parameters) {
-        if (parameters.length <= 1 || !(parameters[1] instanceof String)) return true;
+        if (parameters == null || parameters.length <= 1 || !(parameters[1] instanceof String)) return true;
 
         var executed = switch (message) {
             case "{} issued server command: {}" -> (String)parameters[1];

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/log/LogFilter.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/log/LogFilter.java
@@ -47,18 +47,18 @@ public abstract class LogFilter {
      * @return {@code true} if the message should be logged, {@code false} if it should be filtered out
      */
     protected boolean checkMessage(String message, Object[] parameters) {
-        if (parameters == null || parameters.length <= 1 || !(parameters[1] instanceof String)) return true;
+        if (parameters == null || parameters.length <= 1 || !(parameters[1] instanceof String parameter)) return true;
 
-        var executed = switch (message) {
-            case "{} issued server command: {}" -> (String)parameters[1];
-            case "{0} executed command: /{1}", "{} -> executed command /{}" -> '/' + (String)parameters[1];
+        parameter = switch (message) {
+            case "{} issued server command: {}" -> parameter;
+            case "{0} executed command: /{1}", "{} -> executed command /{}" -> '/' + parameter;
             default -> "";
         };
 
-        if (executed.isEmpty()) return true;
+        if (parameter.isEmpty()) return true;
 
         for (String command : PROTECTED_COMMANDS) {
-            if (executed.startsWith(command)) return false;
+            if (parameter.startsWith(command)) return false;
         }
 
         return true;

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/log/SimpleLogFilter.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/log/SimpleLogFilter.java
@@ -40,11 +40,7 @@ public class SimpleLogFilter extends LogFilter implements Filter {
     @Override
     public boolean isLoggable(LogRecord record) {
         if (filter != null && !filter.isLoggable(record)) return false;
-        var parameters = record.getParameters();
-        if (parameters == null) {
-            parameters = new Object[0];
-        }
-        return checkMessage(record.getMessage(), parameters);
+        return checkMessage(record.getMessage(), record.getParameters());
     }
 
     @Override

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/log/SimpleLogFilter.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/log/SimpleLogFilter.java
@@ -10,9 +10,26 @@ import java.util.logging.Filter;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
+/**
+ * A simple implementation of the LogFilter for Java's built-in logging system.
+ * <p>
+ * This class extends {@link LogFilter} and implements {@link Filter} interface to provide filtering capabilities for the standard Java logging framework.
+ * <p>
+ * This implementation preserves any existing filter that was already set on the logger by chaining it with this filter's functionality.</p>
+ */
 public class SimpleLogFilter extends LogFilter implements Filter {
 
+    /**
+     * The original filter that was set on the logger before this filter was applied.
+     * <p>
+     * This is preserved to maintain the existing filtering chain.
+     */
     private final Filter filter;
+    /**
+     * The logger instance that this filter is attached to.
+     * <p>
+     * Used for filter injection and management.
+     */
     private final Logger logger;
 
     public SimpleLogFilter(Logger logger) {
@@ -23,8 +40,11 @@ public class SimpleLogFilter extends LogFilter implements Filter {
     @Override
     public boolean isLoggable(LogRecord record) {
         if (filter != null && !filter.isLoggable(record)) return false;
-
-        return checkMessage(record.getMessage());
+        var parameters = record.getParameters();
+        if (parameters == null) {
+            parameters = new Object[0];
+        }
+        return checkMessage(record.getMessage(), parameters);
     }
 
     @Override

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/log/SimpleLogFilter.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/log/SimpleLogFilter.java
@@ -40,6 +40,7 @@ public class SimpleLogFilter extends LogFilter implements Filter {
     @Override
     public boolean isLoggable(LogRecord record) {
         if (filter != null && !filter.isLoggable(record)) return false;
+
         return checkMessage(record.getMessage(), record.getParameters());
     }
 


### PR DESCRIPTION
Fix #357.
1. Fix that some commands that shouldn't have been filtered are filtered in Paper.
2. Fix that no commands are filtered in Bungeecord.
3. Fix that all commands are filtered in Velocity.
<details>
<summary>Contrast</summary>
<p>

## Paper
execute command: `/login password` & `/list` & `/about`
### Before
```sh
$ log in
[12:00:00 INFO]: UUID of player foo is xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
[12:00:00 INFO]: foo joined the game
[12:00:00 INFO]: foo[/127.0.0.1:12345] logged in with entity id 100 at ([limbo]0.0, 70.0, 0.0)
$ /login password # no logging as expected
$ /list # unexpected no logging
$ /about # logging as expected
[12:00:15 INFO]: foo issued server command: /about
```
### Now
```sh
$ log in
[12:00:00 INFO]: UUID of player foo is xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
[12:00:00 INFO]: foo joined the game
[12:00:00 INFO]: foo[/127.0.0.1:12345] logged in with entity id 100 at ([limbo]0.0, 70.0, 0.0)
$ /login password # no logging as expected
$ /list # logging as expected
[12:00:10 INFO]: foo issued server command: /list
$ /about # logging as expected
[12:00:15 INFO]: foo issued server command: /about
```
## Bungeecord
Logs are localized.

execute command: `/login password` & `/glist` & `/bungee`
### Before
```sh
$ log in
12:00:00 [信息] [/127.0.0.1:12345] <-> InitialHandler has connected
12:00:00 [信息] [foo] <-> ServerConnector [limbo] has connected
$ /login password # unexpected logging
12:00:05 [信息] foo executed command: /login password
12:00:05 [信息] [foo] <-> ServerConnector [paper] has connected
12:00:05 [信息] [foo] <-> DownstreamBridge <-> [limbo] has disconnected
$ /glist # logging as expected
12:00:10 [信息] foo executed command: /glist
$ /bungeecord # logging as expected
12:00:15 [信息] foo executed command: /bungee
```
### Now
```sh
$ log in
12:00:00 [信息] [/127.0.0.1:12345] <-> InitialHandler has connected
12:00:00 [信息] [foo] <-> ServerConnector [limbo] has connected
$ /login password # no logging as expected
12:00:05 [信息] [foo] <-> ServerConnector [paper] has connected
12:00:05 [信息] [foo] <-> DownstreamBridge <-> [limbo] has disconnected
$ /glist # logging as expected
12:00:10 [信息] foo executed command: /glist
$ /bungeecord # logging as expected
12:00:15 [信息] foo executed command: /bungee
```
## Velocity
`log-command-executions = true`

execute command: `/login password` & `/list` & `/about`
### Before
```sh
$ log in
[12:00:00 INFO]: [connected player] foo (/127.0.0.1:12345) has connected
[12:00:00 INFO]: [server connection] foo -> limbo has connected
[12:00:05 INFO]: [server connection] foo -> paper has connected
[12:00:05 INFO]: [server connection] foo -> limbo has disconnected
$ /login password # no logging as expected
$ /list # unexpected no logging
$ /about # unexpected no logging
```
### Now
```sh
$ log in
[12:00:00 INFO]: [connected player] foo (/127.0.0.1:12345) has connected
[12:00:00 INFO]: [server connection] foo -> limbo has connected
[12:00:05 INFO]: [server connection] foo -> paper has connected
[12:00:05 INFO]: [server connection] foo -> limbo has disconnected
$ /login password # no logging as expected
$ /list # logging as expected
[12:00:10 INFO]: [connected player] foo (/127.0.0.1:12345) -> executed command /list
$ /about # logging as expected
[12:00:15 INFO]: [connected player] foo (/127.0.0.1:12345) -> executed command /about
```

</p>
</details>

This is a **severe** glitch. We need to fix it ASAP.
> Although this glitch has existed for years.