### PR TITLE
feat allow virtual servers on limbo

### DIFF
--- a/API/src/main/java/xyz/kyngs/librelogin/api/server/ServerHandler.java
+++ b/API/src/main/java/xyz/kyngs/librelogin/api/server/ServerHandler.java
@@ -74,7 +74,7 @@ public interface ServerHandler<P, S> {
      *
      * @return The limbo servers
      */
-    Collection<S> getLimboServers();
+    Multimap<String, S> getLimboServers();
 
     /**
      * Registers a new lobby server.
@@ -97,7 +97,8 @@ public interface ServerHandler<P, S> {
      * Registers a new limbo server.
      *
      * @param server The server to register
+     * @param forcedHost The forced host
      */
-    void registerLimboServer(S server);
+    void registerLimboServer(S server, String forcedHost);
 
 }

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/bungeecord/Blockers.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/bungeecord/Blockers.java
@@ -65,7 +65,7 @@ public class Blockers implements Listener {
         if (!authorizationProvider.isAuthorized(event.getPlayer()) && event.getReason() != ServerConnectEvent.Reason.JOIN_PROXY) {
             event.setCancelled(true);
         } else if (authorizationProvider.isAwaiting2FA(event.getPlayer())) {
-            if (!configuration.get(LIMBO).contains(event.getTarget().getName())) {
+            if (!configuration.get(LIMBO).containsValue(event.getTarget().getName())) {
                 event.setCancelled(true);
             }
         }

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/bungeecord/BungeeCordPlatformHandle.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/bungeecord/BungeeCordPlatformHandle.java
@@ -166,7 +166,7 @@ public class BungeeCordPlatformHandle implements PlatformHandle<ProxiedPlayer, S
                                 .add("main", plugin.getDescription().getMain())
                                 .toString()
                 ).toList(),
-                plugin.getServerHandler().getLimboServers().stream().map(this::fromServer).toList(),
+                plugin.getServerHandler().getLimboServers().values().stream().map(this::fromServer).toList(),
                 plugin.getServerHandler().getLobbyServers().values().stream().map(this::fromServer).toList()
         );
     }

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/AuthenticLibreLogin.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/AuthenticLibreLogin.java
@@ -253,7 +253,9 @@ public abstract class AuthenticLibreLogin<P, S> implements LibreLoginPlugin<P, S
         }
 
         if (platformHandle.getPlatformIdentifier().equals("paper")) {
-            LIMBO.setDefault(List.of("limbo"));
+            var limbo = HashMultimap.<String, String>create();
+            limbo.put("root", "limbo");
+            LIMBO.setDefault(limbo);
 
             var lobby = HashMultimap.<String, String>create();
             lobby.put("root", "world");
@@ -442,7 +444,7 @@ public abstract class AuthenticLibreLogin<P, S> implements LibreLoginPlugin<P, S
             var lobby = configuration.get(LOBBY);
 
             for (String value : lobby.values()) {
-                if (limbos.contains(value)) {
+                if (limbos.containsValue(value)) {
                     throw new CorruptedConfigurationException("Lobby server/world %s is also a limbo server/world, this is not allowed".formatted(value));
                 }
             }
@@ -792,7 +794,7 @@ public abstract class AuthenticLibreLogin<P, S> implements LibreLoginPlugin<P, S
             var server = platformHandle.getPlayersServerName(player);
             if (server == null) return;
             var user = databaseProvider.getByUUID(platformHandle.getUUIDForPlayer(player));
-            if (user != null && !getConfiguration().get(LIMBO).contains(server)) {
+            if (user != null && !getConfiguration().get(LIMBO).containsValue(server)) {
                 user.setLastServer(server);
                 databaseProvider.updateUser(user);
             }

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/config/ConfigurationKeys.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/config/ConfigurationKeys.java
@@ -36,12 +36,18 @@ public class ConfigurationKeys {
             ConfigurateHelper::getStringList
     );
 
-    public static final ConfigurationKey<List<String>> LIMBO = new ConfigurationKey<>(
+    public static final Multimap<String, String> LIMBO_DEFAULT = HashMultimap.create();
+    public static final ConfigurationKey<Multimap<String, String>> LIMBO = new ConfigurationKey<>(
             "limbo",
-            List.of("limbo0", "limbo1"),
+            LIMBO_DEFAULT,
             "The authentication servers/worlds, players should be sent to, when not authenticated. On Paper, players will be spawned on the world spawn. THIS SERVERS MUST BE REGISTERED IN THE PROXY CONFIG. IN CASE OF PAPER, THE WORLDS MUST EXIST.",
-            ConfigurateHelper::getStringList
+            ConfigurateHelper::getServerMap
     );
+
+    static {
+        LIMBO_DEFAULT.put("root", "limbo0");
+        LIMBO_DEFAULT.put("root", "limbo1");
+    }
 
     public static final Multimap<String, String> LOBBY_DEFAULT = HashMultimap.create();
     public static final ConfigurationKey<Multimap<String, String>> LOBBY = new ConfigurationKey<>(

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/server/AuthenticServerHandler.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/server/AuthenticServerHandler.java
@@ -31,14 +31,14 @@ public class AuthenticServerHandler<P, S> implements ServerHandler<P, S> {
 
     private final LoadingCache<S, Optional<ServerPing>> pingCache;
     private final AuthenticLibreLogin<P, S> plugin;
-    private final Collection<S> limboServers;
+    private final Multimap<String, S> limboServers;
     private final Multimap<String, S> lobbyServers;
 
     public AuthenticServerHandler(AuthenticLibreLogin<P, S> plugin) {
         this.plugin = plugin;
 
         this.lobbyServers = HashMultimap.create();
-        this.limboServers = new ArrayList<>();
+        this.limboServers = HashMultimap.create();
 
         this.pingCache = Caffeine.newBuilder()
                 .build(server -> {
@@ -59,14 +59,14 @@ public class AuthenticServerHandler<P, S> implements ServerHandler<P, S> {
         if (plugin.getConfiguration().get(ConfigurationKeys.PING_SERVERS))
             plugin.getLogger().info("Pinging servers...");
 
-        for (String limbo : plugin.getConfiguration().get(LIMBO)) {
-            var server = handle.getServer(limbo, true);
-            if (server != null) {
-                registerLimboServer(server);
+        plugin.getConfiguration().get(ConfigurationKeys.LIMBO).forEach((forced, server) -> {
+            var s = handle.getServer(server, true);
+            if (s != null) {
+                registerLimboServer(s, forced);
             } else {
-                plugin.getLogger().warn("Limbo server/world " + limbo + " not found!");
+                plugin.getLogger().warn("Limbo server/world " + server + " not found!");
             }
-        }
+        });
 
         plugin.getConfiguration().get(ConfigurationKeys.LOBBY).forEach((forced, server) -> {
             var s = handle.getServer(server, false);
@@ -143,15 +143,22 @@ public class AuthenticServerHandler<P, S> implements ServerHandler<P, S> {
         return chooseLobbyServerInternal(user, player, remember, null);
     }
 
-    @Override
-    public S chooseLimboServer(User user, P player) {
+    public S chooseLimboServerInternal(@Nullable User user, P player) {
         var event = new AuthenticLimboServerChooseEvent<>(user, player, plugin);
 
         plugin.getEventProvider().fire(plugin.getEventTypes().limboServerChoose, event);
 
         if (event.getServer() != null) return event.getServer();
 
-        return limboServers.stream()
+        var virtual = plugin.getPlatformHandle().getPlayersVirtualHost(player);
+
+        plugin.getLogger().debug("Virtual host for player " + plugin.getPlatformHandle().getUsernameForPlayer(player) + ": " + virtual);
+
+        var servers = virtual == null ? limboServers.get("root") : limboServers.get(virtual);
+
+        if (servers.isEmpty()) servers = limboServers.get("root");
+
+        return servers.stream()
                 .filter(server -> {
                     var ping = getLatestPing(server);
 
@@ -162,12 +169,17 @@ public class AuthenticServerHandler<P, S> implements ServerHandler<P, S> {
     }
 
     @Override
+    public S chooseLimboServer(User user, P player) {
+        return chooseLimboServerInternal(user, player);
+    }
+
+    @Override
     public Multimap<String, S> getLobbyServers() {
         return lobbyServers;
     }
 
     @Override
-    public Collection<S> getLimboServers() {
+    public Multimap<String, S> getLimboServers() {
         return limboServers;
     }
 
@@ -178,8 +190,8 @@ public class AuthenticServerHandler<P, S> implements ServerHandler<P, S> {
     }
 
     @Override
-    public void registerLimboServer(S server) {
+    public void registerLimboServer(S server, String forcedHost) {
         getLatestPing(server);
-        limboServers.add(server);
+        limboServers.put(forcedHost, server);
     }
 }

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/paper/Blockers.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/paper/Blockers.java
@@ -58,7 +58,7 @@ public class Blockers implements Listener {
         if (inLimbo(event.getPlayer())) {
             event.setCancelled(true);
         } else {
-            if (serverHandler.getLimboServers().contains(event.getTo().getWorld()) && !event.getPlayer().hasPermission("librelogin.limbo.access")) {
+            if (serverHandler.getLimboServers().containsValue(event.getTo().getWorld()) && !event.getPlayer().hasPermission("librelogin.limbo.access")) {
                 event.setCancelled(true);
             }
         }

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/paper/PaperListeners.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/paper/PaperListeners.java
@@ -154,8 +154,8 @@ public class PaperListeners extends AuthenticListeners<PaperLibreLogin, Player, 
                 event.setSpawnLocation(bed == null ? world.value().getSpawnLocation() : bed);
             }
             //This is terrible, but should work
-            if (event.getPlayer().hasPlayedBefore() && !plugin.getConfiguration().get(ConfigurationKeys.LIMBO).contains(event.getSpawnLocation().getWorld().getName())) {
-                if (plugin.getConfiguration().get(ConfigurationKeys.LIMBO).contains(world.value().getName())) {
+            if (event.getPlayer().hasPlayedBefore() && !plugin.getConfiguration().get(ConfigurationKeys.LIMBO).containsValue(event.getSpawnLocation().getWorld().getName())) {
+                if (plugin.getConfiguration().get(ConfigurationKeys.LIMBO).containsValue(world.value().getName())) {
                     spawnLocationCache.put(event.getPlayer(), event.getSpawnLocation());
                 } else {
                     return;

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/paper/PaperPlatformHandle.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/paper/PaperPlatformHandle.java
@@ -149,7 +149,7 @@ public class PaperPlatformHandle implements PlatformHandle<Player, World> {
                                 .add("authors", plugin.getDescription().getAuthors())
                                 .toString()
                 ).toList(),
-                plugin.getServerHandler().getLimboServers().stream().map(this::fromWorld).toList(),
+                plugin.getServerHandler().getLimboServers().values().stream().map(this::fromWorld).toList(),
                 plugin.getServerHandler().getLobbyServers().values().stream().map(this::fromWorld).toList()
         );
     }

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/velocity/Blockers.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/velocity/Blockers.java
@@ -53,7 +53,7 @@ public class Blockers {
     @Subscribe(order = PostOrder.FIRST)
     public void onServerConnect(ServerPreConnectEvent event) {
         if (authorizationProvider.isAwaiting2FA(event.getPlayer())) {
-            if (!configuration.get(ConfigurationKeys.LIMBO).contains(event.getOriginalServer().getServerInfo().getName())) {
+            if (!configuration.get(ConfigurationKeys.LIMBO).containsValue(event.getOriginalServer().getServerInfo().getName())) {
                 event.setResult(ServerPreConnectEvent.ServerResult.denied());
             }
         }

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/velocity/VelocityPlatformHandle.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/velocity/VelocityPlatformHandle.java
@@ -144,7 +144,7 @@ public class VelocityPlatformHandle implements PlatformHandle<Player, Registered
                                 .add("desc", plugin.getDescription().toString())
                                 .toString()
                 ).toList(),
-                plugin.getServerHandler().getLimboServers().stream().map(Object::toString).toList(),
+                plugin.getServerHandler().getLimboServers().values().stream().map(Object::toString).toList(),
                 plugin.getServerHandler().getLobbyServers().values().stream().map(Object::toString).toList()
         );
     }


### PR DESCRIPTION
This pull request refactors the handling of "limbo" servers in the authentication system, switching from a simple list to a `Multimap` structure keyed by forced host. This enables more flexible server selection and configuration, particularly for multi-host setups. The changes affect configuration, server registration, and various logic checks throughout the codebase.

**Configuration and Data Structure Changes:**

* The `LIMBO` configuration key in `ConfigurationKeys.java` is changed from a `List<String>` to a `Multimap<String, String>`, allowing limbo servers to be mapped to forced hosts. Default values are updated accordingly.
* The `AuthenticServerHandler` class now manages limbo servers as a `Multimap<String, S>` instead of a `Collection<S>`, and registration uses the forced host as a key. [[1]](diffhunk://#diff-61069d13477fede22b5f329610398556351e49b54779a9630ffe4de4655b856cL34-R41) [[2]](diffhunk://#diff-61069d13477fede22b5f329610398556351e49b54779a9630ffe4de4655b856cL181-R195)

**API and Method Signature Updates:**

* The `ServerHandler` interface updates `getLimboServers()` to return a `Multimap<String, S>`, and `registerLimboServer` now requires a `forcedHost` parameter. [[1]](diffhunk://#diff-aa87b07b2084a106d4585f70b7938452b17da86fa17a13a675ee87a46eac3777L77-R77) [[2]](diffhunk://#diff-aa87b07b2084a106d4585f70b7938452b17da86fa17a13a675ee87a46eac3777R100-R102)

**Logic Adjustments for Limbo Server Checks:**

* All code that previously checked for limbo servers using `.contains(...)` now uses `.containsValue(...)`, reflecting the new multimap structure. This affects event handlers and configuration validation across BungeeCord, Velocity, and Paper platform code. [[1]](diffhunk://#diff-9423585912084d8a415486d17bd27d1b56d151e2d6b6af79beb0cddc006f2336L68-R68) [[2]](diffhunk://#diff-e9d9b84d9e09ab4b1f0128ab7bb4cf40e1e13e60fbaf996fb680b9fc6924fb60L445-R447) [[3]](diffhunk://#diff-e9d9b84d9e09ab4b1f0128ab7bb4cf40e1e13e60fbaf996fb680b9fc6924fb60L794-R796) [[4]](diffhunk://#diff-079993dab5b4d1b90a1381d046d4f6523873bfa12dc1960cde7c30e1eadf0b26L61-R61) [[5]](diffhunk://#diff-f66340bf9327a8220557c470a1cb9bbde37bb4749e9b1e8651277210857a8de4L158-R159) [[6]](diffhunk://#diff-e007062054070845400cfbebfaeefbb04b5fb2439caefc85d48eb4c6af65b606L56-R56)

**Proxy Data and Server List Serialization:**

* When collecting limbo servers for proxy data, code now streams over `getLimboServers().values()` instead of the previous collection, ensuring all registered limbo servers are included regardless of forced host. [[1]](diffhunk://#diff-f208af52a20896759daec274e62844e8e50b4d9f57bd84e11f8733297f439878L169-R169) [[2]](diffhunk://#diff-6215d3ce4fca4e758aa3678af9183c02237bec1ecec6c3e71d2f410895ecc02eL152-R152) [[3]](diffhunk://#diff-72ed5b68c90d0488129254ba472f2821571b34ed6b73dde8eaa47fc52f83ec76L147-R147)

**Server Selection Logic Enhancement:**

* Limbo server selection now considers the player's virtual host, enabling per-host limbo server assignment. If no servers are found for the virtual host, it falls back to the "root" key. [[1]](diffhunk://#diff-61069d13477fede22b5f329610398556351e49b54779a9630ffe4de4655b856cL62-R69) [[2]](diffhunk://#diff-61069d13477fede22b5f329610398556351e49b54779a9630ffe4de4655b856cL146-R161) [[3]](diffhunk://#diff-61069d13477fede22b5f329610398556351e49b54779a9630ffe4de4655b856cR171-R182)