### PR TITLE
Update packetevents-spigot to 2.11.2 for 1.21.11 support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/Plugin/build.gradle.kts
+++ b/Plugin/build.gradle.kts
@@ -175,7 +175,7 @@ dependencies {
     compileOnly("net.luckperms:api:5.4")
 
     //Bungeecord
-    compileOnly("net.md-5:bungeecord-api:1.21-R0.1-SNAPSHOT")
+    compileOnly("net.md-5:bungeecord-api:1.21-R0.4")
     compileOnly("com.github.ProxioDev.ValioBungee:RedisBungee-Bungee:0.12.5")
     libby("net.kyori:adventure-platform-bungeecord:4.1.2")
 
@@ -187,7 +187,7 @@ dependencies {
     //Paper
     compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
     //compileOnly "com.comphenix.protocol:ProtocolLib:5.1.0"
-    libby("com.github.retrooper:packetevents-spigot:2.7.0")
+    libby("com.github.retrooper:packetevents-spigot:2.11.2")
     compileOnly("io.netty:netty-transport:4.1.108.Final")
     compileOnly("com.mojang:datafixerupper:5.0.28") //I hate this so much
     compileOnly("org.apache.logging.log4j:log4j-core:2.23.1")


### PR DESCRIPTION
Hello! 

I ran into a few issues while getting the plugin to compile and run on 1.21.11, so I made two practical changes:

1. **Updated `packetevents-spigot` to `2.11.2`** to allow the plugin to support the newer protocol.
2. **Changed `compileOnly("net.md-5:bungeecord-api:1.21-R0.4")`** to resolve missing chat component dependencies during compilation. 

**Please note:** I have only compiled and tested these changes on a live Purpur 1.21.11 server. It compiles and runs perfectly in this environment, but I haven't tested backwards compatibility with older server versions, so it might need a quick review on your end.

Thanks!