### PR TITLE
Skip the login flow for players authenticated by Minekube Connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 - Add RegEx name validation
 - Allow to retrieve the plugin version from LibreLoginProvider
+- Skip the login flow for players already authenticated by Minekube Connect

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/bungeecord/BungeeCordListener.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/bungeecord/BungeeCordListener.java
@@ -6,6 +6,7 @@
 
 package xyz.kyngs.librelogin.bungeecord;
 
+import io.netty.channel.Channel;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.PendingConnection;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
@@ -15,6 +16,7 @@ import net.md_5.bungee.event.EventHandler;
 import net.md_5.bungee.event.EventPriority;
 import xyz.kyngs.librelogin.api.event.exception.EventCancelledException;
 import xyz.kyngs.librelogin.common.config.ConfigurationKeys;
+import xyz.kyngs.librelogin.common.integration.ConnectIntegration;
 import xyz.kyngs.librelogin.common.listener.AuthenticListeners;
 import xyz.kyngs.librelogin.common.util.GeneralUtil;
 
@@ -56,6 +58,12 @@ public class BungeeCordListener extends AuthenticListeners<BungeeCordLibreLogin,
     public void onPreLogin(PreLoginEvent event) {
         if (plugin.fromFloodgate(event.getConnection().getUniqueId())) return;
 
+        // Minekube Connect authenticated the player at its own edge, there is no Mojang session left
+        // for this proxy to verify. Setting online mode would make the proxy send an encryption
+        // request that can never be answered, so the login flow has to be skipped, just like it is
+        // for Floodgate players above.
+        if (fromConnect(event.getConnection())) return;
+
         runAsyncEvent(event, () -> {
             var result = onPreLogin(event.getConnection().getName(), event.getConnection().getAddress().getAddress());
 
@@ -93,9 +101,50 @@ public class BungeeCordListener extends AuthenticListeners<BungeeCordLibreLogin,
         }
     }
 
+    /**
+     * Reads the connection channel out of the {@link PendingConnection} implementation, so that the
+     * attributes other systems put on it can be looked at. BungeeCord exposes neither the field nor
+     * its type through its API, hence the reflection.
+     *
+     * @return the channel, or null if it could not be read
+     */
+    private Channel getChannel(PendingConnection connection) {
+        try {
+            Field field = connection.getClass().getDeclaredField("ch");
+            field.setAccessible(true);
+
+            Object wrapper = field.get(connection);
+            if (wrapper == null) return null;
+
+            return (Channel) wrapper.getClass().getMethod("getHandle").invoke(wrapper);
+        } catch (ReflectiveOperationException | ClassCastException e) {
+            plugin.getLogger().debug("Failed to read the channel of a pending connection.", e);
+            return null;
+        }
+    }
+
+    /**
+     * Checks whether the connection was already authenticated by Minekube Connect, which marks such
+     * connections with the {@code connect-player} channel attribute before any login event fires.
+     * <p>
+     * This fails open: if the channel cannot be read the connection is treated as if Connect was not
+     * installed, which is exactly what happened before this check existed.
+     */
+    private boolean fromConnect(PendingConnection connection) {
+        return ConnectIntegration.isConnectChannel(getChannel(connection));
+    }
+
     @EventHandler(priority = EventPriority.LOWEST)
     public void onProfileRequest(LoginEvent event) {
         if (plugin.fromFloodgate(event.getConnection().getUniqueId())) return;
+
+        if (fromConnect(event.getConnection())) {
+            // Connect has already put the player's real uuid on the connection, rewriting it here
+            // would replace it with LibreLogin's own. Remember the uuid, as the channel is no longer
+            // reachable once the player is online.
+            plugin.getConnectIntegration().addPlayer(event.getConnection().getUniqueId());
+            return;
+        }
 
         // Note to future self: NEVER EVER RUN THIS ASYNC, IT WILL BREAK PLUGINS
 

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/AuthenticLibreLogin.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/AuthenticLibreLogin.java
@@ -56,6 +56,7 @@ import xyz.kyngs.librelogin.common.database.provider.LibreLoginPostgreSQLDatabas
 import xyz.kyngs.librelogin.common.database.provider.LibreLoginSQLiteDatabaseProvider;
 import xyz.kyngs.librelogin.common.event.AuthenticEventProvider;
 import xyz.kyngs.librelogin.common.image.AuthenticImageProjector;
+import xyz.kyngs.librelogin.common.integration.ConnectIntegration;
 import xyz.kyngs.librelogin.common.integration.FloodgateIntegration;
 import xyz.kyngs.librelogin.common.integration.luckperms.LuckPermsIntegration;
 import xyz.kyngs.librelogin.common.listener.LoginTryListener;
@@ -98,6 +99,7 @@ public abstract class AuthenticLibreLogin<P, S> implements LibreLoginPlugin<P, S
     private final Multimap<P, CancellableTask> cancelOnExit;
     private final PlatformHandle<P, S> platformHandle;
     private final Set<String> forbiddenPasswords;
+    private final ConnectIntegration connectApi;
     protected Logger logger;
     private AuthenticPremiumProvider premiumProvider;
     private AuthenticEventProvider<P, S> eventProvider;
@@ -123,6 +125,7 @@ public abstract class AuthenticLibreLogin<P, S> implements LibreLoginPlugin<P, S
         platformHandle = providePlatformHandle();
         forbiddenPasswords = new HashSet<>();
         cancelOnExit = HashMultimap.create();
+        connectApi = new ConnectIntegration();
     }
 
     public Map<Class<?>, DatabaseConnectorRegistration<?, ?>> getDatabaseConnectors() {
@@ -812,6 +815,26 @@ public abstract class AuthenticLibreLogin<P, S> implements LibreLoginPlugin<P, S
 
     public boolean fromFloodgate(UUID uuid) {
         return floodgateApi != null && uuid != null && floodgateApi.isFloodgateId(uuid);
+    }
+
+    public ConnectIntegration getConnectIntegration() {
+        return connectApi;
+    }
+
+    public boolean fromConnect(UUID uuid) {
+        return connectApi.isConnectId(uuid);
+    }
+
+    /**
+     * Whether the player has already been authenticated before the connection reached this proxy,
+     * either by Floodgate or by Minekube Connect. LibreLogin must not run its own login flow for
+     * such players.
+     *
+     * @param uuid the player's uuid
+     * @return whether the player has been authenticated externally
+     */
+    public boolean externallyAuthenticated(UUID uuid) {
+        return fromFloodgate(uuid) || fromConnect(uuid);
     }
 
     protected void shutdownProxy(int code) {

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/integration/ConnectIntegration.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/integration/ConnectIntegration.java
@@ -1,0 +1,61 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package xyz.kyngs.librelogin.common.integration;
+
+import io.netty.channel.Channel;
+import io.netty.util.AttributeKey;
+
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Recognizes players that have already been authenticated by Minekube Connect.
+ * <p>
+ * Connect terminates the player's connection at its own edge, performs the Mojang handshake there,
+ * and then relays the player into the proxy over a local channel which it marks with the
+ * {@code connect-player} attribute. There is no second Mojang session left for the proxy to verify,
+ * so forcing online mode on such a connection makes the proxy send an encryption request that can
+ * never be answered and the login never completes.
+ * <p>
+ * Reading the marker needs no compile time dependency on Connect: Netty interns attribute keys by
+ * name, so the attribute is simply absent when Connect is not installed. This is the same approach
+ * the listeners already use for Floodgate's {@code floodgate-player} attribute.
+ * <p>
+ * The channel is only reachable while the player is logging in, so the UUIDs recognized during
+ * login are remembered here and dropped again when the player disconnects. That gives the rest of
+ * the plugin a UUID based check with the same shape as {@link FloodgateIntegration#isFloodgateId}.
+ */
+public class ConnectIntegration {
+
+    private static final AttributeKey<?> CONNECT_ATTR = AttributeKey.valueOf("connect-player");
+
+    private final Set<UUID> players = ConcurrentHashMap.newKeySet();
+
+    /**
+     * Checks whether the given connection channel has been marked by Connect.
+     *
+     * @param channel the connection channel, may be null if it could not be read
+     * @return whether the player behind the channel has already been authenticated by Connect
+     */
+    public static boolean isConnectChannel(Channel channel) {
+        return channel != null && channel.hasAttr(CONNECT_ATTR) && channel.attr(CONNECT_ATTR).get() != null;
+    }
+
+    public void addPlayer(UUID uuid) {
+        if (uuid != null) players.add(uuid);
+    }
+
+    public void removePlayer(UUID uuid) {
+        if (uuid != null) players.remove(uuid);
+    }
+
+    public boolean isConnectId(UUID uuid) {
+        return uuid != null && players.contains(uuid);
+    }
+
+}

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/common/listener/AuthenticListeners.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/common/listener/AuthenticListeners.java
@@ -38,7 +38,7 @@ public class AuthenticListeners<Plugin extends AuthenticLibreLogin<P, S>, P, S> 
     protected void onPostLogin(P player, User user) {
         var ip = platformHandle.getIP(player);
         var uuid = platformHandle.getUUIDForPlayer(player);
-        if (plugin.fromFloodgate(uuid)) return;
+        if (plugin.externallyAuthenticated(uuid)) return;
 
         if (user == null) {
             user = plugin.getDatabaseProvider().getByUUID(uuid);
@@ -63,6 +63,7 @@ public class AuthenticListeners<Plugin extends AuthenticLibreLogin<P, S>, P, S> 
     }
 
     protected void onPlayerDisconnect(P player) {
+        plugin.getConnectIntegration().removePlayer(platformHandle.getUUIDForPlayer(player));
         plugin.onExit(player);
         plugin.getAuthorizationProvider().onExit(player);
     }
@@ -268,11 +269,11 @@ public class AuthenticListeners<Plugin extends AuthenticLibreLogin<P, S>, P, S> 
 
     protected BiHolder<Boolean, S> chooseServer(P player, @Nullable String ip, @Nullable User user) {
         var id = platformHandle.getUUIDForPlayer(player);
-        var fromFloodgate = plugin.fromFloodgate(id);
+        var externallyAuthenticated = plugin.externallyAuthenticated(id);
 
         var sessionTime = Duration.ofSeconds(plugin.getConfiguration().get(ConfigurationKeys.SESSION_TIMEOUT));
 
-        if (fromFloodgate) {
+        if (externallyAuthenticated) {
             user = null;
         } else if (user == null) {
             user = plugin.getDatabaseProvider().getByUUID(id);
@@ -282,7 +283,7 @@ public class AuthenticListeners<Plugin extends AuthenticLibreLogin<P, S>, P, S> 
             ip = platformHandle.getIP(player);
         }
 
-        if (fromFloodgate || user.autoLoginEnabled() || (sessionTime != null && user.getLastAuthentication() != null && ip.equals(user.getIp()) && user.getLastAuthentication().toLocalDateTime().plus(sessionTime).isAfter(LocalDateTime.now()))) {
+        if (externallyAuthenticated || user.autoLoginEnabled() || (sessionTime != null && user.getLastAuthentication() != null && ip.equals(user.getIp()) && user.getLastAuthentication().toLocalDateTime().plus(sessionTime).isAfter(LocalDateTime.now()))) {
             return new BiHolder<>(true, plugin.getServerHandler().chooseLobbyServer(user, player, true, false));
         } else {
             return new BiHolder<>(false, plugin.getServerHandler().chooseLimboServer(user, player));

--- a/Plugin/src/main/java/xyz/kyngs/librelogin/velocity/VelocityListeners.java
+++ b/Plugin/src/main/java/xyz/kyngs/librelogin/velocity/VelocityListeners.java
@@ -23,6 +23,7 @@ import io.netty.util.AttributeKey;
 import net.kyori.adventure.text.Component;
 import xyz.kyngs.librelogin.api.event.exception.EventCancelledException;
 import xyz.kyngs.librelogin.common.config.ConfigurationKeys;
+import xyz.kyngs.librelogin.common.integration.ConnectIntegration;
 import xyz.kyngs.librelogin.common.listener.AuthenticListeners;
 import xyz.kyngs.librelogin.common.util.GeneralUtil;
 
@@ -78,6 +79,33 @@ public class VelocityListeners extends AuthenticListeners<VelocityLibreLogin, Pl
         super(plugin);
     }
 
+    private static Channel getChannel(InboundConnection connection) throws IllegalAccessException {
+        if (INITIAL_CONNECTION_DELEGATE != null) {
+            connection = (InboundConnection) INITIAL_CONNECTION_DELEGATE.get(connection);
+        }
+
+        Object mcConnection = INITIAL_MINECRAFT_CONNECTION.get(connection);
+
+        return (Channel) CHANNEL.get(mcConnection);
+    }
+
+    /**
+     * Checks whether the connection was already authenticated by Minekube Connect, which marks such
+     * connections with the {@code connect-player} channel attribute before any login event fires.
+     * <p>
+     * Unlike the Floodgate check this one fails open: if the channel cannot be read we simply
+     * proceed as if Connect was not installed, which is exactly what happened before this check
+     * existed.
+     */
+    private boolean fromConnect(InboundConnection connection) {
+        try {
+            return ConnectIntegration.isConnectChannel(getChannel(connection));
+        } catch (Exception e) {
+            plugin.getLogger().debug("Failed to check if player is coming from Connect.", e);
+            return false;
+        }
+    }
+
     @Subscribe(order = PostOrder.LAST)
     public void onPostLogin(PostLoginEvent event) {
         onPostLogin(event.getPlayer(), null);
@@ -94,6 +122,14 @@ public class VelocityListeners extends AuthenticListeners<VelocityLibreLogin, Pl
 
         if (existing != null && plugin.fromFloodgate(existing.getId())) return;
 
+        if (existing != null && fromConnect(event.getConnection())) {
+            // Connect has already put the player's real uuid and skin properties into the profile,
+            // rebuilding it from the original one would throw both away. Remember the uuid, as the
+            // channel is no longer reachable once the player is online.
+            plugin.getConnectIntegration().addPlayer(existing.getId());
+            return;
+        }
+
         var profile = plugin.getDatabaseProvider().getByName(event.getUsername());
 
         var gProfile = event.getOriginalProfile();
@@ -109,15 +145,8 @@ public class VelocityListeners extends AuthenticListeners<VelocityLibreLogin, Pl
 
         // If floodgate is present, attempt to extract the floodgate player from the connection channel.
         if (plugin.floodgateEnabled()) {
-            Channel channel;
-            InboundConnection connection = event.getConnection();
             try {
-                if (INITIAL_CONNECTION_DELEGATE != null) {
-                    connection = (InboundConnection) INITIAL_CONNECTION_DELEGATE.get(connection);
-                }
-
-                Object mcConnection = INITIAL_MINECRAFT_CONNECTION.get(connection);
-                channel = (Channel) CHANNEL.get(mcConnection);
+                Channel channel = getChannel(event.getConnection());
 
                 if (channel.attr(FLOODGATE_ATTR).get() != null) {
                     return; // Player is coming from Floodgate
@@ -128,6 +157,14 @@ public class VelocityListeners extends AuthenticListeners<VelocityLibreLogin, Pl
                 event.setResult(PreLoginEvent.PreLoginComponentResult.denied(Component.text("Internal LibreLogin error")));
                 return;
             }
+        }
+
+        // Minekube Connect authenticated the player at its own edge, there is no Mojang session
+        // left for this proxy to verify. Forcing online mode would make the proxy send an encryption
+        // request that can never be answered, so the login flow has to be skipped, just like it is
+        // for Floodgate players above.
+        if (fromConnect(event.getConnection())) {
+            return; // Player has already been authenticated by Connect
         }
 
         var result = onPreLogin(event.getUsername(), event.getConnection().getRemoteAddress().getAddress());


### PR DESCRIPTION
Hi! This extends the Floodgate exemption to cover Minekube Connect, which conflicts with LibreLogin in the same way and at the same points.

## The problem

Connect terminates the player's connection at its own edge, performs the Mojang online-mode handshake there, and then relays the player into the proxy over a local Netty channel. On that inner connection it forces offline mode and supplies the player's real Mojang UUID and skin properties itself.

That means there is no second Mojang session left for the proxy to verify. Three things then go wrong:

1. **Pre-login.** `VelocityListeners#onPreLogin` runs at `PostOrder.LAST` and `BungeeCordListener#onPreLogin` at `HIGHEST`, so LibreLogin's decision replaces Connect's. For any player LibreLogin considers premium the result is `FORCE_ONLINE`, and the proxy sends an encryption request that can never be answered — the login hangs and never completes. (This is why disabling premium autologin is the workaround people currently use: with no `premiumUUID` the pre-login result can only ever be `FORCE_OFFLINE`, which happens to agree with Connect.)
2. **Game profile.** `onProfileRequest` rebuilds the profile from `getOriginalProfile()`, which discards the UUID and the skin properties Connect put there. This one happens even with autologin disabled, so those players silently get a different UUID and a default skin.
3. **Post-login.** `onPostLogin` and `chooseServer` then track the player and route them to limbo, because nothing tells them the player is already authenticated.

## The fix

Connect marks the connection with a `connect-player` Netty channel attribute, deliberately mirroring Floodgate's `floodgate-player`, and it is set when the channel is created — so it is readable everywhere the Floodgate attribute already is, including from handlers registered at the very earliest priority.

So this PR follows the exemption you already have for Floodgate, at the same three points:

- `VelocityListeners#onPreLogin` — skip the login flow, right after the existing Floodgate branch. I pulled the channel reflection out of that branch into a `getChannel(InboundConnection)` helper so both checks share it; the Floodgate branch itself is otherwise unchanged.
- `VelocityListeners#onProfileRequest` / `BungeeCordListener#onProfileRequest` — leave the profile alone, alongside the existing `fromFloodgate` check.
- `BungeeCordListener#onPreLogin` — same guard as the Floodgate one directly above it.
- `AuthenticListeners#onPostLogin` and `#chooseServer` — the existing `fromFloodgate` checks become `externallyAuthenticated`, which is `fromFloodgate || fromConnect`. The Connect path is the same as the Floodgate one: no tracking, straight to a lobby server.

New `common/integration/ConnectIntegration`, next to `FloodgateIntegration`, holds the attribute key and the check.

## Notes for review

- **No new dependency, and nothing to soft-depend on.** Netty interns attribute keys by name, so the attribute is simply absent when Connect is not installed and the check compiles and runs either way. That is also why there is no `connectEnabled()` gate to match `floodgateEnabled()` — there are no classes to load, so there is nothing to guard.
- **Post-login lookups need a UUID, but the channel is only reachable during login.** So `ConnectIntegration` remembers the UUIDs it recognises at profile-request time and drops them again in `onPlayerDisconnect` — the same add-on-login / remove-on-disconnect lifecycle `FloodgateApi` uses for its own player map. One caveat I want to flag rather than hide: if a connection dies between the profile request and the player object existing, no disconnect fires and that UUID stays in the set. It is bounded (one entry per distinct player, re-adding is idempotent) and only read during join, but if you would rather have an expiring cache there, that is a one-line change and I am happy to make it.
- **The Connect check fails open.** If the channel cannot be read it behaves exactly as it did before this check existed, and logs at debug. I deliberately did not extend the Floodgate branch's deny-on-error behaviour to it, so that installations without Connect cannot start failing logins because of this PR.
- **Paper is untouched.** The `packetevents` login path there is a different shape and I had no way to exercise it, so I left it alone rather than guess. The shared `AuthenticListeners` changes do apply on Paper, but `fromConnect` is never true there because nothing registers a UUID, so Paper behaviour is unchanged.
- **No test.** The project has no test source set, and adding a test framework inside a bug-fix PR seemed like the wrong call. If you would like one, tell me which framework you want and I will add it.

Verified with `./gradlew build` (compiles clean, `checkLicenses` passes). I have not been able to run this against a live Connect + LibreLogin proxy, so a second pair of eyes on the Bungee `PendingConnection` channel lookup in particular would be welcome.

Reference for the attribute, in case it is useful: <https://github.com/minekube/connect-java/blob/main/docs/login-plugin-integration.md>.
